### PR TITLE
fix: fix permissions in base workflow for semantic-release

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -13,6 +13,8 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  issues: write
+  pull-requests: write
 
 # Allow one concurrent deployment
 concurrency:


### PR DESCRIPTION
Allow semantic release writing to issues and pull requests